### PR TITLE
Add OCR script to convert bank statements to CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # StatementToCSV
+
+## Project Description
+
+This project aims to provide a Python script that can OCR (Optical Character Recognition) bank statement PDFs and convert them into CSV files. The generated CSV files are formatted to be compatible with BlueCoins and Cashew, two popular personal finance management applications.
+
+## How to Use
+
+1. Install the required Python packages by running:
+   ```
+   pip install -r requirements.txt
+   ```
+
+2. Run the script with the following command:
+   ```
+   python ocr_to_csv.py <path_to_pdf> <output_csv_file>
+   ```
+
+3. The script will process the PDF, perform OCR, and generate a CSV file with the extracted data.
+
+## Contributing
+
+We welcome contributions to this project. If you would like to contribute, please follow these steps:
+
+1. Fork the repository.
+2. Create a new branch for your feature or bugfix.
+3. Make your changes and commit them with a clear message.
+4. Push your changes to your forked repository.
+5. Create a pull request to the main repository.
+
+Thank you for your contributions!

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project aims to provide a Python script that can OCR (Optical Character Rec
    python ocr_to_csv.py <path_to_pdf> <output_csv_file>
    ```
 
-3. The script will process the PDF, perform OCR, and generate a CSV file with the extracted data.
+3. The script will ask if the output is for Cashew or BlueCoins, process the PDF, perform OCR, and generate a CSV file with the extracted data.
 
 ## Contributing
 

--- a/ocr_to_csv.py
+++ b/ocr_to_csv.py
@@ -23,8 +23,14 @@ def parse_ocr_results(ocr_results):
                 data.append(line.strip().split())
     return data
 
-def save_to_csv(data, output_csv_file):
+def save_to_csv(data, output_csv_file, app_type):
     df = pd.DataFrame(data)
+    if app_type.lower() == "cashew":
+        # Format the data for Cashew
+        df.columns = ["Date", "Description", "Amount"]
+    elif app_type.lower() == "bluecoins":
+        # Format the data for BlueCoins
+        df.columns = ["(1)Type", "(2)Date", "(3)Item or Payee", "(4)Amount", "(5)Parent Category", "(6)Category", "(7)Account Type", "(8)Account", "(9)Notes", "(10)Label", "(11)Status", "(12)Split"]
     df.to_csv(output_csv_file, index=False)
 
 if __name__ == "__main__":
@@ -35,7 +41,9 @@ if __name__ == "__main__":
     pdf_path = sys.argv[1]
     output_csv_file = sys.argv[2]
 
+    app_type = input("Is the output for Cashew or BlueCoins? ")
+
     images = pdf_to_images(pdf_path)
     ocr_results = ocr_images(images)
     data = parse_ocr_results(ocr_results)
-    save_to_csv(data, output_csv_file)
+    save_to_csv(data, output_csv_file, app_type)

--- a/ocr_to_csv.py
+++ b/ocr_to_csv.py
@@ -1,0 +1,41 @@
+import pytesseract
+from pdf2image import convert_from_path
+import pandas as pd
+import sys
+
+def pdf_to_images(pdf_path):
+    images = convert_from_path(pdf_path)
+    return images
+
+def ocr_images(images):
+    ocr_results = []
+    for image in images:
+        text = pytesseract.image_to_string(image)
+        ocr_results.append(text)
+    return ocr_results
+
+def parse_ocr_results(ocr_results):
+    data = []
+    for result in ocr_results:
+        lines = result.split('\n')
+        for line in lines:
+            if line.strip():
+                data.append(line.strip().split())
+    return data
+
+def save_to_csv(data, output_csv_file):
+    df = pd.DataFrame(data)
+    df.to_csv(output_csv_file, index=False)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python ocr_to_csv.py <path_to_pdf> <output_csv_file>")
+        sys.exit(1)
+
+    pdf_path = sys.argv[1]
+    output_csv_file = sys.argv[2]
+
+    images = pdf_to_images(pdf_path)
+    ocr_results = ocr_images(images)
+    data = parse_ocr_results(ocr_results)
+    save_to_csv(data, output_csv_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytesseract
+pdf2image
+pandas


### PR DESCRIPTION
Add a Python script to OCR bank statement PDFs and convert them to CSV files.

* **README.md**
  - Add project description explaining the purpose of the repository.
  - Add instructions on how to use the script to OCR bank statements and convert them to CSV.
  - Add a section on how to contribute to the project.

* **requirements.txt**
  - List required Python packages: `pytesseract`, `pdf2image`, and `pandas`.

* **ocr_to_csv.py**
  - Import necessary libraries: `pytesseract`, `pdf2image`, and `pandas`.
  - Define a function to convert a PDF to images using `pdf2image`.
  - Define a function to perform OCR on the images using `pytesseract`.
  - Define a function to parse the OCR results and extract relevant data.
  - Define a function to save the extracted data to a CSV file in the format required by BlueCoins and Cashew.
  - Add command-line interface to run the script with PDF path and output CSV file as arguments.

